### PR TITLE
build(dockerfile): add flavor that builds from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,6 @@ bin/
 .tmp/
 lerna-debug.log
 .npmrc
+
+# Cover all the nested node_modules directories of pkgs as well
+**/node_modules

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ otherwise it's `2`, indicating an issue.
 
 To avoid the response being pretty-printed JSON, you can pass in the `--prety=false` flag via the CLI in addition to the `--request='{...}'` parameter. This will cause the JSON output to be printed on a single line.
 
-## Build container image locally
+## Build release container image locally
 
 ```sh
 DOCKER_BUILDKIT=1 docker build --build-arg NPM_PKG_VERSION=latest -f ./Dockerfile . -t dcil
 ```
 
-## Run locally via Docker
+## Run release container image locally via Docker
 
 ```sh
 docker \
@@ -86,6 +86,38 @@ docker \
   node_modules/@dci-lint/cmd-api-server/dist/lib/main/typescript/cmd/dci-lint-cli.js \
   lint-git-repo \
   --request='{"cloneUrl": "https://github.com/petermetz/dci-lint.git", "targetPhrasePatterns": ["something-mean"]}'
+```
+
+## Build development container image locally
+
+```sh
+DOCKER_BUILDKIT=1 docker build -f ./src.Dockerfile . -t dcil
+```
+
+## Run development container image locally via Docker
+
+*One-off Linting Request via CLI arguments:*
+
+```sh
+docker \
+  run \
+  --rm \
+  dcil \
+  pkg/cmd-api-server/dist/lib/main/typescript/cmd/dci-lint-cli.js \
+  lint-git-repo \
+  --request='{"cloneUrl": "https://github.com/petermetz/dci-lint.git", "targetPhrasePatterns": ["something-mean"]}'
+```
+
+*Continuously Listen to Linting Requests via HTTP Server:*
+
+```sh
+docker \
+  run \
+  --rm \
+  --publish 3000:3000 \
+  --publish 4000:4000 \
+  dcil \
+  pkg/cmd-api-server/dist/lib/main/typescript/cmd/dci-lint-server.js
 ```
 
 # Documentation

--- a/src.Dockerfile
+++ b/src.Dockerfile
@@ -1,0 +1,83 @@
+FROM debian:bullseye-20221205
+
+SHELL ["/bin/bash", "-c"]
+
+ARG APP=/usr/src/app/
+ENV APP_USER=appuser
+
+# GUI: 3000, API: 4000
+EXPOSE 3000 4000
+
+RUN groupadd --gid 1000 appuser \
+  && useradd --uid 1000 --gid appuser --shell /bin/bash --create-home ${APP_USER}
+
+RUN apt update && apt install -y curl git
+
+# Install OpenJDK 11
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+apt-get install -y --no-install-recommends \
+        openjdk-11-jdk
+# Prints installed java version, just for checking
+RUN java --version
+
+
+RUN mkdir -p "${APP}log/"
+RUN chown -R $APP_USER:$APP_USER "${APP}log/"
+
+WORKDIR ${APP}
+
+COPY --chown=${APP_USER}:${APP_USER} ./pkg/cmd-api-server/docker-entrypoint.sh /usr/local/bin/
+COPY --chown=${APP_USER}:${APP_USER} ./pkg/cmd-api-server/healthcheck.sh /
+RUN chown -R $APP_USER:$APP_USER ${APP}
+
+USER $APP_USER
+
+ENV TZ=Etc/UTC
+ENV NODE_ENV=production
+
+ENV NVM_DIR /home/${APP_USER}/.nvm
+ENV NODE_VERSION 18.12.1
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# Install nvm with node and npm
+RUN mkdir -p ${NVM_DIR}
+RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash \
+  && source $NVM_DIR/nvm.sh \
+  && nvm install $NODE_VERSION \
+  && nvm alias default $NODE_VERSION \
+  && nvm use default \
+  && npm install -g npm@8.19.2
+
+ARG NPM_PKG_VERSION=latest
+RUN npm install @dci-lint/cmd-api-server@${NPM_PKG_VERSION} --production
+
+ENV COCKPIT_TLS_ENABLED=false
+ENV COCKPIT_CORS_DOMAIN_CSV=\*
+ENV COCKPIT_MTLS_ENABLED=false
+ENV API_MTLS_ENABLED=false
+ENV API_TLS_ENABLED=false
+ENV COCKPIT_TLS_CERT_PEM=-
+ENV COCKPIT_TLS_KEY_PEM=-
+ENV COCKPIT_TLS_CLIENT_CA_PEM=-
+ENV COCKPIT_WWW_ROOT=/usr/src/app/node_modules/@dci-lint/cockpit/www/
+ENV API_TLS_CERT_PEM=-
+ENV API_TLS_CLIENT_CA_PEM=-
+ENV API_TLS_KEY_PEM=-
+ENV COCKPIT_HOST=0.0.0.0
+ENV API_HOST=0.0.0.0
+ENV API_PORT=4000
+ENV PORT=3000
+ENV LOG_LEVEL=DEBUG
+
+HEALTHCHECK --interval=1s --timeout=5s --start-period=1s --retries=60 CMD /healthcheck.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+COPY --chown=${APP_USER}:${APP_USER} ./ ./
+RUN corepack enable && corepack prepare yarn@3.3.0 --activate
+RUN yarn install --immutable
+RUN yarn build
+RUN yarn test:all --bail
+
+CMD ["pkg/cmd-api-server/dist/lib/main/typescript/cmd/dci-lint-server.js"]


### PR DESCRIPTION
This will enable us to have automated builds on DockerHub use the
new src.Dockerfile which will always contain the latest and greatest
code and therefore will be suitable to test unreleased changes via
containers as well.

The latter also feeds into the goal of making it easier to publish new
GitHub Action releases for DCI-Lint.

Fixes #18

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>