### PR TITLE
chore(release): publish v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.3](https://github.com/petermetz/dci-lint/compare/v0.6.2...v0.6.3) (2022-12-21)
+
+**Note:** Version bump only for package @dci-lint/monorepo
+
+
+
+
+
 ## [0.6.2](https://github.com/petermetz/dci-lint/compare/v0.5.1...v0.6.2) (2022-12-21)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "pkg/*"
   ],
-  "version": "0.6.2",
+  "version": "0.6.3",
   "npmClient": "yarn",
   "useWorkspaces": "true",
   "command": {

--- a/pkg/cmd-api-server/CHANGELOG.md
+++ b/pkg/cmd-api-server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.3](https://github.com/petermetz/dci-lint/compare/v0.6.2...v0.6.3) (2022-12-21)
+
+**Note:** Version bump only for package @dci-lint/cmd-api-server
+
+
+
+
+
 ## [0.6.2](https://github.com/petermetz/dci-lint/compare/v0.5.1...v0.6.2) (2022-12-21)
 
 

--- a/pkg/cmd-api-server/package.json
+++ b/pkg/cmd-api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dci-lint/cmd-api-server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "API server that combines and exposes all the functionality of a DCI Lint deployment through a unified REST API interface.",
   "bin": {
     "dci-lint": "./dist/lib/main/typescript/cmd/dci-lint-server.js"
@@ -64,10 +64,10 @@
   },
   "homepage": "https://github.com/petermetz/dci-lint#readme",
   "dependencies": {
-    "@dci-lint/cockpit": "0.6.2",
-    "@dci-lint/common": "0.6.2",
-    "@dci-lint/core": "0.6.2",
-    "@dci-lint/core-api": "0.6.2",
+    "@dci-lint/cockpit": "0.6.3",
+    "@dci-lint/common": "0.6.3",
+    "@dci-lint/core": "0.6.3",
+    "@dci-lint/core-api": "0.6.3",
     "body-parser": "1.20.1",
     "compression": "1.7.4",
     "convict": "6.2.3",

--- a/pkg/cockpit/CHANGELOG.md
+++ b/pkg/cockpit/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.3](https://github.com/petermetz/dci-lint/compare/v0.6.2...v0.6.3) (2022-12-21)
+
+**Note:** Version bump only for package @dci-lint/cockpit
+
+
+
+
+
 ## [0.6.2](https://github.com/petermetz/dci-lint/compare/v0.5.1...v0.6.2) (2022-12-21)
 
 

--- a/pkg/cockpit/package.json
+++ b/pkg/cockpit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dci-lint/cockpit",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "files": [
     "www/*"
   ],
@@ -22,8 +22,8 @@
     "@angular/platform-browser-dynamic": "15.0.2",
     "@angular/router": "15.0.2",
     "@capacitor/core": "1.5.1",
-    "@dci-lint/common": "0.6.2",
-    "@dci-lint/core-api": "0.6.2",
+    "@dci-lint/common": "0.6.3",
+    "@dci-lint/core-api": "0.6.3",
     "@ionic-native/core": "5.36.0",
     "@ionic-native/splash-screen": "5.36.0",
     "@ionic-native/status-bar": "5.36.0",

--- a/pkg/common/CHANGELOG.md
+++ b/pkg/common/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.3](https://github.com/petermetz/dci-lint/compare/v0.6.2...v0.6.3) (2022-12-21)
+
+**Note:** Version bump only for package @dci-lint/common
+
+
+
+
+
 ## [0.6.2](https://github.com/petermetz/dci-lint/compare/v0.5.1...v0.6.2) (2022-12-21)
 
 **Note:** Version bump only for package @dci-lint/common

--- a/pkg/common/package.json
+++ b/pkg/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dci-lint/common",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Universal library used by both front end and back end components of DCI Lint. Aims to be a developer swiss army knife.",
   "main": "dist/lib/main/typescript/index.js",
   "mainMinified": "dist/common.node.umd.min.js",

--- a/pkg/core-api/CHANGELOG.md
+++ b/pkg/core-api/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.3](https://github.com/petermetz/dci-lint/compare/v0.6.2...v0.6.3) (2022-12-21)
+
+**Note:** Version bump only for package @dci-lint/core-api
+
+
+
+
+
 ## [0.6.2](https://github.com/petermetz/dci-lint/compare/v0.5.1...v0.6.2) (2022-12-21)
 
 

--- a/pkg/core-api/package.json
+++ b/pkg/core-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dci-lint/core-api",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Contains type definitions/interfaces for the kernel of the codebase. Kept separate from the implementation so that it is easier to use it as a dependency.",
   "main": "dist/lib/main/typescript/index.js",
   "mainMinified": "dist/core-api.node.umd.min.js",

--- a/pkg/core/CHANGELOG.md
+++ b/pkg/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.3](https://github.com/petermetz/dci-lint/compare/v0.6.2...v0.6.3) (2022-12-21)
+
+**Note:** Version bump only for package @dci-lint/core
+
+
+
+
+
 ## [0.6.2](https://github.com/petermetz/dci-lint/compare/v0.5.1...v0.6.2) (2022-12-21)
 
 

--- a/pkg/core/package.json
+++ b/pkg/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dci-lint/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Contains lower level abstractions/implementation that is to be shared by multiple other, higher level packages of the project.",
   "main": "dist/lib/main/typescript/index.js",
   "mainMinified": "dist/core.node.umd.min.js",
@@ -50,8 +50,8 @@
   },
   "homepage": "https://github.com/petermetz/dci-lint#readme",
   "dependencies": {
-    "@dci-lint/common": "0.6.2",
-    "@dci-lint/core-api": "0.6.2",
+    "@dci-lint/common": "0.6.3",
+    "@dci-lint/core-api": "0.6.3",
     "axios": "0.21.4",
     "fast-glob": "3.2.4",
     "fast-safe-stringify": "2.1.1",

--- a/pkg/test-api-client/CHANGELOG.md
+++ b/pkg/test-api-client/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.3](https://github.com/petermetz/dci-lint/compare/v0.6.2...v0.6.3) (2022-12-21)
+
+**Note:** Version bump only for package @dci-lint/test-api-client
+
+
+
+
+
 ## [0.6.2](https://github.com/petermetz/dci-lint/compare/v0.5.1...v0.6.2) (2022-12-21)
 
 

--- a/pkg/test-api-client/package.json
+++ b/pkg/test-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dci-lint/test-api-client",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Integration tests for the DCI Lint API Client package (formerly known as the  SDK package that has been renamed for to purpose of being less ambiguous)",
   "main": "dist/lib/main/typescript/index.js",
   "mainMinified": "dist/test-api-client.node.umd.min.js",
@@ -50,10 +50,10 @@
   },
   "homepage": "https://github.com/petermetz/dci-lint#readme",
   "dependencies": {
-    "@dci-lint/cmd-api-server": "0.6.2",
-    "@dci-lint/common": "0.6.2",
-    "@dci-lint/core": "0.6.2",
-    "@dci-lint/core-api": "0.6.2",
+    "@dci-lint/cmd-api-server": "0.6.3",
+    "@dci-lint/common": "0.6.3",
+    "@dci-lint/core": "0.6.3",
+    "@dci-lint/core-api": "0.6.3",
     "axios": "0.21.4",
     "body-parser": "1.20.1",
     "express": "4.18.2",

--- a/pkg/test-cmd-api-server/CHANGELOG.md
+++ b/pkg/test-cmd-api-server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.6.3](https://github.com/petermetz/dci-lint/compare/v0.6.2...v0.6.3) (2022-12-21)
+
+**Note:** Version bump only for package @dci-lint/test-cmd-api-server
+
+
+
+
+
 ## [0.6.2](https://github.com/petermetz/dci-lint/compare/v0.5.1...v0.6.2) (2022-12-21)
 
 

--- a/pkg/test-cmd-api-server/package.json
+++ b/pkg/test-cmd-api-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dci-lint/test-cmd-api-server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Integration tests for the DCI Lint API Client package (formerly known as the  SDK package that has been renamed for to purpose of being less ambiguous)",
   "main": "dist/lib/main/typescript/index.js",
   "mainMinified": "dist/test-cmd-api-server.node.umd.min.js",
@@ -50,10 +50,10 @@
   },
   "homepage": "https://github.com/petermetz/dci-lint#readme",
   "dependencies": {
-    "@dci-lint/cmd-api-server": "0.6.2",
-    "@dci-lint/common": "0.6.2",
-    "@dci-lint/core": "0.6.2",
-    "@dci-lint/core-api": "0.6.2",
+    "@dci-lint/cmd-api-server": "0.6.3",
+    "@dci-lint/common": "0.6.3",
+    "@dci-lint/core": "0.6.3",
+    "@dci-lint/core-api": "0.6.3",
     "axios": "0.21.4",
     "body-parser": "1.20.1",
     "express": "4.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,14 +1936,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dci-lint/cmd-api-server@0.6.2, @dci-lint/cmd-api-server@workspace:pkg/cmd-api-server":
+"@dci-lint/cmd-api-server@0.6.3, @dci-lint/cmd-api-server@workspace:pkg/cmd-api-server":
   version: 0.0.0-use.local
   resolution: "@dci-lint/cmd-api-server@workspace:pkg/cmd-api-server"
   dependencies:
-    "@dci-lint/cockpit": 0.6.2
-    "@dci-lint/common": 0.6.2
-    "@dci-lint/core": 0.6.2
-    "@dci-lint/core-api": 0.6.2
+    "@dci-lint/cockpit": 0.6.3
+    "@dci-lint/common": 0.6.3
+    "@dci-lint/core": 0.6.3
+    "@dci-lint/core-api": 0.6.3
     "@types/compression": 1.7.0
     "@types/convict": 5.2.1
     "@types/cors": 2.8.6
@@ -1981,7 +1981,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dci-lint/cockpit@0.6.2, @dci-lint/cockpit@workspace:pkg/cockpit":
+"@dci-lint/cockpit@0.6.3, @dci-lint/cockpit@workspace:pkg/cockpit":
   version: 0.0.0-use.local
   resolution: "@dci-lint/cockpit@workspace:pkg/cockpit"
   dependencies:
@@ -1998,8 +1998,8 @@ __metadata:
     "@angular/router": 15.0.2
     "@capacitor/cli": 1.5.1
     "@capacitor/core": 1.5.1
-    "@dci-lint/common": 0.6.2
-    "@dci-lint/core-api": 0.6.2
+    "@dci-lint/common": 0.6.3
+    "@dci-lint/core-api": 0.6.3
     "@ionic-native/core": 5.36.0
     "@ionic-native/splash-screen": 5.36.0
     "@ionic-native/status-bar": 5.36.0
@@ -2029,7 +2029,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dci-lint/common@0.6.2, @dci-lint/common@workspace:pkg/common":
+"@dci-lint/common@0.6.3, @dci-lint/common@workspace:pkg/common":
   version: 0.0.0-use.local
   resolution: "@dci-lint/common@workspace:pkg/common"
   dependencies:
@@ -2048,7 +2048,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dci-lint/core-api@0.6.2, @dci-lint/core-api@workspace:pkg/core-api":
+"@dci-lint/core-api@0.6.3, @dci-lint/core-api@workspace:pkg/core-api":
   version: 0.0.0-use.local
   resolution: "@dci-lint/core-api@workspace:pkg/core-api"
   dependencies:
@@ -2062,12 +2062,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@dci-lint/core@0.6.2, @dci-lint/core@workspace:pkg/core":
+"@dci-lint/core@0.6.3, @dci-lint/core@workspace:pkg/core":
   version: 0.0.0-use.local
   resolution: "@dci-lint/core@workspace:pkg/core"
   dependencies:
-    "@dci-lint/common": 0.6.2
-    "@dci-lint/core-api": 0.6.2
+    "@dci-lint/common": 0.6.3
+    "@dci-lint/core-api": 0.6.3
     "@types/express": 4.17.13
     "@types/fs-extra": 9.0.5
     "@types/temp": 0.8.34
@@ -2143,10 +2143,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dci-lint/test-api-client@workspace:pkg/test-api-client"
   dependencies:
-    "@dci-lint/cmd-api-server": 0.6.2
-    "@dci-lint/common": 0.6.2
-    "@dci-lint/core": 0.6.2
-    "@dci-lint/core-api": 0.6.2
+    "@dci-lint/cmd-api-server": 0.6.3
+    "@dci-lint/common": 0.6.3
+    "@dci-lint/core": 0.6.3
+    "@dci-lint/core-api": 0.6.3
     "@types/body-parser": 1.19.2
     "@types/express": 4.17.15
     axios: 0.21.4
@@ -2160,10 +2160,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dci-lint/test-cmd-api-server@workspace:pkg/test-cmd-api-server"
   dependencies:
-    "@dci-lint/cmd-api-server": 0.6.2
-    "@dci-lint/common": 0.6.2
-    "@dci-lint/core": 0.6.2
-    "@dci-lint/core-api": 0.6.2
+    "@dci-lint/cmd-api-server": 0.6.3
+    "@dci-lint/common": 0.6.3
+    "@dci-lint/core": 0.6.3
+    "@dci-lint/core-api": 0.6.3
     "@types/body-parser": 1.19.2
     "@types/express": 4.17.15
     axios: 0.21.4


### PR DESCRIPTION
No new features - just testing the release automation 
where new container images should be published with
the latest npm packages.

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>