### PR TITLE
refactor(cmd-api-server): add operationId to OpenAPI specs for health-check

### DIFF
--- a/pkg/cmd-api-server/healthcheck.sh
+++ b/pkg/cmd-api-server/healthcheck.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-wget -O- http://127.0.0.1:4000/api/v1/api-server/healthcheck
+wget -O- http://127.0.0.1:4000/api/v1/api-server/health-check

--- a/pkg/cmd-api-server/src/main/json/openapi.json
+++ b/pkg/cmd-api-server/src/main/json/openapi.json
@@ -51,9 +51,10 @@
     }
   },
   "paths": {
-    "/api/v1/api-server/healthcheck": {
+    "/api/v1/api-server/health-check": {
       "get": {
         "summary": "Can be used to verify liveness of an API server instance",
+        "operationId": "healthCheckV1",
         "description": "Returns the current timestamp of the API server as proof of health/liveness",
         "parameters": [],
         "responses": {

--- a/pkg/cmd-api-server/src/main/typescript/api-server.ts
+++ b/pkg/cmd-api-server/src/main/typescript/api-server.ts
@@ -245,14 +245,14 @@ export class ApiServer {
     const openApiValidatorMiddleware = this.createOpenApiValidator();
     app.use(openApiValidatorMiddleware);
 
-    const healthcheckHandler = (req: Request, res: Response) => {
+    const healthCheckHandler = (req: Request, res: Response) => {
       res.json({
         success: true,
         createdAt: new Date(),
         memoryUsage: process.memoryUsage(),
       });
     };
-    app.get("/api/v1/api-server/healthcheck", healthcheckHandler);
+    app.get("/api/v1/api-server/health-check", healthCheckHandler);
 
     this.log.info(`Starting to install web services...`);
 

--- a/pkg/cmd-api-server/src/main/typescript/generated/openapi/typescript-axios/api.ts
+++ b/pkg/cmd-api-server/src/main/typescript/generated/openapi/typescript-axios/api.ts
@@ -96,8 +96,8 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1ApiServerHealthcheckGet: async (options: any = {}): Promise<RequestArgs> => {
-            const localVarPath = `/api/v1/api-server/healthcheck`;
+        healthCheckV1: async (options: any = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/api-server/health-check`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -136,8 +136,8 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiV1ApiServerHealthcheckGet(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<HealthCheckResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1ApiServerHealthcheckGet(options);
+        async healthCheckV1(options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<HealthCheckResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.healthCheckV1(options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -156,8 +156,8 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1ApiServerHealthcheckGet(options?: any): AxiosPromise<HealthCheckResponse> {
-            return localVarFp.apiV1ApiServerHealthcheckGet(options).then((request) => request(axios, basePath));
+        healthCheckV1(options?: any): AxiosPromise<HealthCheckResponse> {
+            return localVarFp.healthCheckV1(options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -176,8 +176,8 @@ export class DefaultApi extends BaseAPI {
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public apiV1ApiServerHealthcheckGet(options?: any) {
-        return DefaultApiFp(this.configuration).apiV1ApiServerHealthcheckGet(options).then((request) => request(this.axios, this.basePath));
+    public healthCheckV1(options?: any) {
+        return DefaultApiFp(this.configuration).healthCheckV1(options).then((request) => request(this.axios, this.basePath));
     }
 }
 


### PR DESCRIPTION
This would be a breaking change normally but since
we are still sub-1.0.0 it's okay to make this kind of
change for now.

Fixes #33

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>