### PR TITLE
fix(cmd-api-server): health-check endpoint crash - no OpenAPI metadata

### DIFF
--- a/pkg/cmd-api-server/src/main/typescript/api-server.ts
+++ b/pkg/cmd-api-server/src/main/typescript/api-server.ts
@@ -297,11 +297,28 @@ export class ApiServer {
   }
 
   createOpenApiValidator(): OpenApiRequestHandler[] {
+    // TODO: @petermetz Use a more robust, recursive merging utility for this.
+    // On the one hand this code is simpler and does not add more dependencies.
+    // On the other hand it is the prime suspect if any strange bugs occur
+    // regarding the OpenAPI spec validation...
+    const apiSpec = {
+      ...OAS_API_SERVER,
+      components: {
+        schemas: {
+          ...OAS_API_SERVER.components.schemas,
+          ...OAS_CORE_API.components.schemas,
+        },
+      },
+      paths: {
+        ...OAS_API_SERVER.paths,
+        ...OAS_CORE_API.paths,
+      },
+    };
+
+    this.log.info("Merged OpenAPI spec for request validation: %o", apiSpec);
+
     return OpenApiValidator.middleware({
-      apiSpec: {
-        ...OAS_API_SERVER,
-        ...OAS_CORE_API,
-      } as any,
+      apiSpec: apiSpec as never,
       validateRequests: true,
       validateResponses: false,
     });

--- a/pkg/cmd-api-server/src/main/typescript/public-api.ts
+++ b/pkg/cmd-api-server/src/main/typescript/public-api.ts
@@ -8,3 +8,5 @@ export {
   IPluginImport,
   IApiServerOptions,
 } from "./config/config-service";
+
+export * from "./generated/openapi/typescript-axios/index";

--- a/pkg/test-cmd-api-server/src/test/typescript/integration/api-server.test.ts
+++ b/pkg/test-cmd-api-server/src/test/typescript/integration/api-server.test.ts
@@ -4,8 +4,13 @@ import http from "http";
 import test, { Test } from "tape-promise/tape";
 
 import { Configuration, DefaultApi as DciLintApi } from "@dci-lint/core-api";
+import { Configuration as ApiServerApiConfiguration } from "@dci-lint/cmd-api-server";
+import { DefaultApi as ApiServerApi } from "@dci-lint/cmd-api-server";
 import { ApiServer, ConfigService } from "@dci-lint/cmd-api-server";
 import { IListenOptions, LogLevelDesc, Servers } from "@dci-lint/common";
+
+const RE_ISO_8601_DATE_TIME_STRING: RegExp =
+  /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))/;
 
 const logLevel: LogLevelDesc = "TRACE";
 
@@ -69,4 +74,50 @@ test("Lint a git repo", async (t: Test) => {
   t.ok(res2, "Response truthy OK");
   t.equal(res2.status, 200, "Response status equals 200 OK");
   t.notEqual(res2.data.linterErrors.length, 0, "Linter errors found OK");
+});
+
+test("Respond to Health-check Requests", async (t: Test) => {
+  const server = http.createServer();
+  const listenOptions: IListenOptions = {
+    hostname: "127.0.0.1",
+    port: 0,
+    server,
+  };
+  const addressInfo = (await Servers.listen(listenOptions)) as AddressInfo;
+
+  const configService = new ConfigService();
+  const apiServerOptions = configService.newExampleConfig();
+  apiServerOptions.configFile = "";
+  apiServerOptions.apiCorsDomainCsv = "*";
+  apiServerOptions.apiPort = addressInfo.port;
+  apiServerOptions.apiTlsEnabled = false;
+  apiServerOptions.cockpitTlsEnabled = false;
+  apiServerOptions.cockpitPort = 0;
+  apiServerOptions.logLevel = logLevel;
+  apiServerOptions.cockpitWwwRoot = "./node_modules/@dci-lint/cockpit/www/";
+  const config = configService.newExampleConfigConvict(apiServerOptions);
+  const apiServer = new ApiServer({
+    httpServerApi: server,
+    config: config.getProperties(),
+  });
+
+  await apiServer.start();
+  test.onFinish(async () => await apiServer.shutdown());
+
+  const { port } = addressInfo;
+  const apiHost = `http://127.0.0.1:${port}`;
+  const configuration = new ApiServerApiConfiguration({ basePath: apiHost });
+  const apiClient = new ApiServerApi(configuration);
+
+  const cloneUrl = "https://github.com/petermetz/random-english-words.git";
+
+  const res1 = await apiClient.healthCheckV1();
+
+  t.ok(res1, "Response truthy OK");
+  t.equal(res1.status, 200, "Response status equals 200 OK");
+  t.match(
+    res1.data.createdAt,
+    RE_ISO_8601_DATE_TIME_STRING,
+    "res1.data.createdAt matches ISO DateTime regular expression."
+  );
 });


### PR DESCRIPTION
The issue was that the API server code did a shallow merge on the
OpenAPI spec objects that we pull in from the .json files.
The merge is still shallow but it is deep "enough" now that it
does a merging of paths and schema components so that the
core-api and cmd-api-server openapi.json spec files can both be
used for request validation purposes.

The metadata lookups (used by the validation) were failing because
the shallow object merge was lossy, e.g. only one of the specs was
actually included by the validator.

Fixes #35

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>