### PR TITLE
fix(dockerfile): health-check is broken due to missing wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ EXPOSE 3000 4000
 RUN groupadd --gid 1000 appuser \
   && useradd --uid 1000 --gid appuser --shell /bin/bash --create-home ${APP_USER}
 
-RUN apt update && apt install -y curl git
+RUN apt update && apt install -y curl wget git
 
 RUN mkdir -p "${APP}log/"
 RUN chown -R $APP_USER:$APP_USER "${APP}log/"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ DOCKER_BUILDKIT=1 docker build --build-arg NPM_PKG_VERSION=latest -f ./Dockerfil
 
 ## Run release container image locally via Docker
 
+*One-off Linting Request via CLI arguments:*
+
 ```sh
 docker \
   run \
@@ -86,6 +88,16 @@ docker \
   node_modules/@dci-lint/cmd-api-server/dist/lib/main/typescript/cmd/dci-lint-cli.js \
   lint-git-repo \
   --request='{"cloneUrl": "https://github.com/petermetz/dci-lint.git", "targetPhrasePatterns": ["something-mean"]}'
+```
+
+*Continuously Listen to Linting Requests via HTTP Server:*
+
+```sh
+docker \
+  run \
+  --rm \
+  dcil \
+  node_modules/@dci-lint/cmd-api-server/dist/lib/main/typescript/cmd/dci-lint-server.js
 ```
 
 ## Build development container image locally

--- a/src.Dockerfile
+++ b/src.Dockerfile
@@ -11,7 +11,7 @@ EXPOSE 3000 4000
 RUN groupadd --gid 1000 appuser \
   && useradd --uid 1000 --gid appuser --shell /bin/bash --create-home ${APP_USER}
 
-RUN apt update && apt install -y curl git
+RUN apt update && apt install -y curl wget git
 
 # Install OpenJDK 11
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
It was also broken due to other bugs in the API server health-check
endpoint itself but that was rectified in the meantime.

The solution is to just install wget in the dockerfiles because
Debian does not ship with them by default (as opposed to Ubuntu
which does)

Fixes #31

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>