### PR TITLE
ci(github): set up fly.io automated deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,18 @@ Follow these instructions to set up a GitHub Action that automatically lints inc
 
 ## Public test instance
 
-Accessible at: https://dci-lint.herokuapp.com/
+The GUI and the REST API are both accessible at these addresses (backed by the same free-tier [fly.io](https://fly.io) instance):
+- https://dci-lint.top/
+- https://www.dci-lint.top/
+- https://dci-lint.fly.dev
 
 ## Self-hosting on your own hardware
 
 You can self host DCI-lint by running the container image as shown below,
-after which you can access the GUI locally at http:/localhost:3000
+after which you can access the GUI locally at http://localhost:3000
 
 ```sh
-docker run --rm -e PORT=3000 -p 3000:3000 ghcr.io/petermetz/dci-lint:0.5.1
+docker run --rm -e PORT=3000 -p 3000:3000 ghcr.io/petermetz/dci-lint:0.6.4
 ```
 
 If you'd rather use the command line interface instead of the web interface,
@@ -30,7 +33,7 @@ docker \
   run \
   --rm \
   --env DCI_LINT_LOG_LEVEL=DEBUG \
-  ghcr.io/petermetz/dci-lint:0.5.1 \
+  ghcr.io/petermetz/dci-lint:0.6.4 \
   node_modules/@dci-lint/cmd-api-server/dist/lib/main/typescript/cmd/dci-lint-cli.js \
   lint-git-repo \
   --request='{"cloneUrl": "https://github.com/petermetz/dci-lint.git", "targetPhrasePatterns": ["something-mean"]}'
@@ -39,7 +42,7 @@ docker \
 
 ## Command Line Interface
 
-After the project has been built, the CLI can be invoked as follows:
+After the project has been built (`$ yarn configure`), the CLI can be invoked as follows:
 
 ```sh
 DCI_LINT_LOG_LEVEL=ERROR node \
@@ -68,7 +71,7 @@ whether the linter found any errors or not.
 If there were no errors then the exit code is `0`
 otherwise it's `2`, indicating an issue.
 
-To avoid the response being pretty-printed JSON, you can pass in the `--prety=false` flag via the CLI in addition to the `--request='{...}'` parameter. This will cause the JSON output to be printed on a single line.
+To avoid the response being pretty-printed JSON, you can pass in the `--pretty=false` flag via the CLI in addition to the `--request='{...}'` parameter. This will cause the JSON output to be printed on a single line.
 
 ## Build release container image locally
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,46 @@
+# fly.toml file generated for dci-lint on 2022-12-21T22:12:17-08:00
+
+app = "dci-lint"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[experimental]
+  allowed_public_ports = [3000, 4000]
+  auto_rollback = true
+
+[[services]]
+    internal_port = 4000
+    protocol = 'tcp'
+
+    [[services.ports]]
+        handlers = ['http']
+        port = 4000
+
+[[services]]
+  http_checks = []
+  internal_port = 3000
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"


### PR DESCRIPTION
Also:
- Updated the README.md file to point to the newly
deployed public test instance with the newly purchased
test domain (dci-lint.top) as well.
- Fixed typos in the README.md file such as prety vs pretty
- Updated the container image versions referenced by the
README to be the current latest (v0.6.4)

Fixes #32

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>